### PR TITLE
Add starship class name to table columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ At this point, you should be able to run the dev server and access it locally in
 
 You will add several capabilities to the existing application:
 
-- As a user, I want to be able to filter the starships table by name, model, or starship class name, so that I can quickly access the starships I want to add to the encounter
-- As a user, I want to be able to see a list of the starships I've added to an encounter that I'm editing, so that I know what I've added
-- As a user, I want the list of added starships to include the ability to remove any starship from the encounter
-- As a user, I want to be able to create an encounter that includes the starships I've added
+- As a user, I want to be able to filter the starships table by name, model, or starship class name, so that I can quickly access the starships I want to add to the encounter ([Issue #1](https://github.com/KrisPlunkett/star-wars-encounter-builder/issues/1))
+- As a user, I want to be able to see a list of the starships I've added to an encounter that I'm editing, so that I know what I've added ([Issue #2](https://github.com/KrisPlunkett/star-wars-encounter-builder/issues/2))
+- As a user, I want the list of added starships to include the ability to remove any starship from the encounter ([Issue #3](https://github.com/KrisPlunkett/star-wars-encounter-builder/issues/3))
+- As a user, I want to be able to create an encounter that includes the starships I've added ([Issue #4](https://github.com/KrisPlunkett/star-wars-encounter-builder/issues/4)
 
-1. Add the starship class names to the table columns
+1. ~~Add the starship class names to the table columns~~ (Resolved by [Pull Request #5](https://github.com/KrisPlunkett/star-wars-encounter-builder/pull/5))
 2. Implement a change handler for the search input, live-filtering the table data based on a comparison of the input text and a union of starship name, model, and starship class name
 3. Finish implementing the add button by adding a click handler that adds the associated starship to the encounter being edited
 4. Create a new React component that will take the place of the existing `ul#encounter-starships`. The component should be a list of added starships, each with a button to remove from the encounter.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Encounter Builder",
   "description": "Recruiting Project for Ambition",
   "author": "Ambition Team",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "build": "npm install --legacy-peer-deps --include=dev && gulp build",

--- a/recruiting_project/__init__.py
+++ b/recruiting_project/__init__.py
@@ -1,1 +1,1 @@
-VERSION='0.1.0'
+VERSION = '1.0.0'

--- a/recruiting_project/encounters/serializers.py
+++ b/recruiting_project/encounters/serializers.py
@@ -4,13 +4,15 @@ from recruiting_project.encounters.models import Starship, Encounter, Mob
 
 
 class StarshipSerializer(ModelSerializer):
+    starship_class_name = CharField(source='starship_class.name', read_only=True)
 
     class Meta:
         model = Starship
         fields = [
             'name',
             'model',
-            'starship_class',
+            'starship_class_id',
+            'starship_class_name',
             'cost_in_credits',
             'crew',
             'passengers',

--- a/recruiting_project/frontend/src/encounters/components/EncounterBuilderApp.js
+++ b/recruiting_project/frontend/src/encounters/components/EncounterBuilderApp.js
@@ -10,6 +10,7 @@ class EncounterBuilderApp extends BaseApp {
         this.columns = [
             {fieldName: 'name', displayName: 'Name'},
             {fieldName: 'model', displayName: 'Model'},
+            {fieldName: 'starship_class_name', displayName: 'Class'},
             this.renderActions.bind(this),
         ];
         this.state = {


### PR DESCRIPTION
# Render Class in Starships table

- [x] Add `starship_class_name` to the starship API
- [x] Change `starship_class` to `starship_class_id` starship API
- [x] Render the `starship_class_name` as `Class` in the UI
- [x] Bump the API and UI versions as per [SEMVER](https://semver.org/)
- [x] Update README to link to issues and task 1 as resolved by this PR 

## Before
No `Class` column

<img width="1753" alt="image" src="https://user-images.githubusercontent.com/6193588/173167044-eca9ac05-c5ed-4dd5-a392-54911f71824c.png">

## After
`Class` column

<img width="1779" alt="image" src="https://user-images.githubusercontent.com/6193588/173167084-20421efb-6fd5-4031-b28d-d3ea6918a4dc.png">
