### PR TITLE
Finish create encounter front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You will add several capabilities to the existing application:
 3. ~~Finish implementing the add button by adding a click handler that adds the associated starship to the encounter being edited~~ (Resolved by [Pull Request #9](https://github.com/KrisPlunkett/star-wars-encounter-builder/pull/9))
 4. ~~Create a new React component that will take the place of the existing `ul#encounter-starships`. The component should be a list of added starships, each with a button to remove from the encounter.~~ (Resolved by [Pull Request #10](https://github.com/KrisPlunkett/star-wars-encounter-builder/pull/10))
 5. ~~Add a django form/view that takes a list of starships and creates an encounter with the given starships~~ (Resolved by [Pull Request #11](https://github.com/KrisPlunkett/star-wars-encounter-builder/pull/11))
-6. Finish implementing the "Create Encounter" button by adding a click handler that posts the form via ajax
+6. ~~Finish implementing the "Create Encounter" button by adding a click handler that posts the form via ajax~~ (Resolved by [Pull Request #12](https://github.com/KrisPlunkett/star-wars-encounter-builder/pull/12))
 
 Once you're ready to submit, package the project as a compressed file, and share a link to the compressed package. Please be prepared to demo your project live in our technical interview.
 

--- a/recruiting_project/encounters/api.py
+++ b/recruiting_project/encounters/api.py
@@ -1,3 +1,4 @@
+from rest_framework.parsers import FormParser, MultiPartParser, JSONParser
 from rest_framework.viewsets import ModelViewSet
 
 from recruiting_project.encounters.models import Starship, Encounter
@@ -29,6 +30,8 @@ class EncountersModelViewSet(ModelViewSet):
     """
     Model viewset for encounters API
     """
+    parser_classes = [JSONParser, FormParser, MultiPartParser]
+
     def get_serializer_class(self):
         if self.request.method == 'GET':
             return EncounterListSerializer

--- a/recruiting_project/encounters/serializers.py
+++ b/recruiting_project/encounters/serializers.py
@@ -45,6 +45,7 @@ class EncounterListSerializer(ModelSerializer):
     class Meta:
         model = Encounter
         fields = [
+            'id',
             'mobs',
             'name',
             'notes',
@@ -65,6 +66,7 @@ class EncounterCreateSerializer(ModelSerializer):
     class Meta:
         model = Encounter
         fields = [
+            'id',
             'mobs',
             'name',
             'notes',

--- a/recruiting_project/frontend/src/encounters/components/EncounterBuilderApp.js
+++ b/recruiting_project/frontend/src/encounters/components/EncounterBuilderApp.js
@@ -18,6 +18,8 @@ class EncounterBuilderApp extends BaseApp {
         ];
         this.state = {
             encounter: {
+                name: "",
+                notes: "",
                 starships: [],
             },
             starships: [],
@@ -95,23 +97,66 @@ class EncounterBuilderApp extends BaseApp {
         return (
             <>
                 <h4>Encounter Summary</h4>
+                <form>
+                    <div>
+                        <label htmlFor="name">Enter an encounter name</label>
+                        <input required={true} type="text" maxLength={256} placeholder="Name" name="name" value={this.state.encounter.name} onChange={this.handleEncounterNameChange.bind(this)}/>
+                    </div>
+                    <div>
+                        <label htmlFor="notes">Enter encounter notes</label>
+                        <textarea name="notes" placeholder="Notes" value={this.state.encounter.notes} onChange={this.handleEncounterNotesChange.bind(this)} />
+                    </div>
+                    { this.renderCreateEncounterButton() }
+                </form>
                 <EncounterStarships
                     encounterStarships={this.state.encounter.starships}
                     handleRemoveShip={this.handleRemoveShip.bind(this)}
                 />
-                <form>
-                    { this.renderCreateEncounterButton() }
-                </form>
             </>
         );
     }
 
+    handleEncounterNameChange(event) {
+        this.setState({
+            encounter: {
+                ...this.state.encounter,
+                name: event.target.value,
+            }
+        });
+    }
+
+    handleEncounterNotesChange(event) {
+        this.setState({
+            encounter: {
+                ...this.state.encounter,
+                notes: event.target.value,
+            }
+        });
+    }
+
     renderCreateEncounterButton() {
         return this.state.encounter.starships.length ? (
-            <button type="submit" className="btn btn-primary">Create Encounter</button>
+            <button type="button" onClick={this.handleSubmit.bind(this)} className="btn btn-primary">Create Encounter</button>
         ) : (
             <span>Add starships to encounter to create</span>
         );
+    }
+
+    handleSubmit() {
+        const { encounter } = this.state;
+        const payload = {
+            name: encounter.name,
+            notes: encounter.notes,
+            mobs: encounter.starships.map(starship => starship.id),
+        }
+        request.post('/encounters/api/encounters/', payload)
+            .then(response => {
+                const createdEncounterId = response.data.id;
+                window.location = `/encounters/api/encounters/${createdEncounterId}`;
+            }).catch(err => {
+                console.log(err);
+                window.alert("Failed to create encounter - see console for more info.");
+            });
     }
 
     renderActions(rowKey, record, index) {
@@ -123,6 +168,7 @@ class EncounterBuilderApp extends BaseApp {
     handleAddShip(record) {
         this.setState({
             encounter: {
+                ...this.state.encounter,
                 starships: [...this.state.encounter.starships,  { name: record.name, id: record.id }],
             }
         })
@@ -133,6 +179,7 @@ class EncounterBuilderApp extends BaseApp {
         starships.splice(index, 1);
         this.setState({
             encounter: {
+                ...this.state.encounter,
                 starships,
             }
         });


### PR DESCRIPTION
- [x] Allow user to pass name and notes when creating an encounter
- [x] Clicking create encounter now submits the form to create the encounter 
- [x] Upon successful form submission - redirect to the list encounter view to see the new encounter (no UI yet as it's out of scope)

 ## Before
No name or notes fields and clicking create encounter just reloaded the page.
![Kapture 2022-06-15 at 16 50 04](https://user-images.githubusercontent.com/6193588/173936087-5949764f-4475-4922-b37d-c881fe549f27.gif)


## After
Enter name and notes and clicking create encounter submits the form and redirects to the new encounter.
![Kapture 2022-06-15 at 16 52 22](https://user-images.githubusercontent.com/6193588/173936939-f1213847-359f-4b03-a615-d9088e8bd25a.gif)

